### PR TITLE
Update/server side block styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository is a WordPress plugin that includes a single custom block style.
 
 All you really need to get started is: 
 
-- The courage to edit a few lines in a single JavaScript file. 
+- The courage to edit a few lines in a single PHP file. 
 - Knowledge of CSS.
 - A WordPress site to upload this plugin to (Alternatively, you can run a single Terminal command to create a quick development environment instead).  
 
@@ -22,29 +22,37 @@ All you really need to get started is:
 
 Adding + editing block styles is a three step process: 
 
-**1. Open up the `block-styles.js` file and adjust the block type, name, and label for your new block style.**
+**1. Open up the `index.php` file and adjust the block type, name, and label for your new block style.**
 
 For example, the built-in example adds a "Blue Paragraph" block style to the core Paragraph block: 
 
 ```
-wp.blocks.registerBlockStyle( 'core/paragraph', {
-	name: 'blue-paragraph',
-	label: 'Blue Paragraph'
-} );
+register_block_style(
+	'core/paragraph',
+	array(
+		'name'			=> 'blue-paragraph',
+		'label'			=> 'Blue Paragraph',
+		'style_handle'	=> 'block-styles-stylesheet',
+	)
+);
 ```
 
 Here's another example, adding an "Awesome Cover" style to the Cover block: 
 
 ```
-wp.blocks.registerBlockStyle( 'core/cover', {
-	name: 'awesome-cover',
-	label: 'Awesome Cover'
-} );
+register_block_style(
+	'core/cover',
+	array(
+		'name'			=> 'awesome-cover',
+		'label'			=> 'Awesome Cover',
+		'style_handle'	=> 'block-styles-stylesheet',
+	)
+);
 ```
 
-Those four lines are all you need to declare the new block style. The block name in the first line should refer to the official title for the block, but the `name` and `label` can follow whatever format you'd like. `name` will be used to generate a new classname for your block style, so please don't include any spaces there. 
+Those 8 lines are all you need to declare the new block style. The block name in the second line should refer to the official title for the block, but the `name` and `label` can follow whatever format you'd like. `name` will be used to generate a new classname for your block style, so please don't include any spaces there. 
 
-If you'd like to add multiple block styles in the same plugin, just duplicate those four lines.
+If you'd like to add multiple block styles in the same plugin, just duplicate those 8 lines.
 
 **2. From there, add the CSS to style your new block style.**
 
@@ -62,6 +70,11 @@ Open up the `style.css` file, and add any CSS styles for your block. Anything yo
 **3. Test your changes.**
 
 Zip up the plugin with your changes and upload to your site, or if you'd prefer, test the changes in real-time using the included [Docker-powered dev environment](DOCKER.md). 🎉
+
+## More Documentation
+
+- [Block Style Variations](https://developer.wordpress.org/block-editor/developers/filters/block-filters/#block-style-variations) in the Block Editor Handbook
+- [Server-side Registration Helper](https://developer.wordpress.org/block-editor/developers/filters/block-filters/#server-side-registration-helper) in the Block Editor Handbook (This is the method of registration used in these examples.)
 
 ## Questions? 
 

--- a/block.js
+++ b/block.js
@@ -1,9 +1,0 @@
-/**
- * Declare the block you'd like to style. 
- * Duplicate and customize the four lines below for each style variation you'd like to add.
- */
-
-wp.blocks.registerBlockStyle( 'core/paragraph', {
-	name: 'blue-paragraph',
-	label: 'Blue Paragraph'
-} );

--- a/index.php
+++ b/index.php
@@ -38,14 +38,6 @@ if ( function_exists( 'register_block_style' ) ) {
 
 	add_action( 'init', 'block_styles_register_block_styles' );
 }
- * Enqueue Block Styles Stylesheet
- */
-function block_styles_enqueue_stylesheet() {
-	wp_enqueue_style( 'block-styles-stylesheet',
-		plugins_url( 'style.css', __FILE__ ) 
-	);
-}
-add_action( 'enqueue_block_assets', 'block_styles_enqueue_stylesheet' );
 
 /**
  * Register Block Styles

--- a/index.php
+++ b/index.php
@@ -37,18 +37,3 @@ if ( function_exists( 'register_block_style' ) ) {
 	}
 
 	add_action( 'init', 'block_styles_register_block_styles' );
-}
-
-/**
- * Register Block Styles
- */
-if ( function_exists( 'register_block_style' ) ) {
-	register_block_style(
-		'core/paragraph',
-		array(
-			'name'			=> 'blue-paragraph',
-			'label'			=> 'Blue Paragraph',
-			'style_handle'	=> 'block-styles-stylesheet',
-		)
-	);
-}

--- a/index.php
+++ b/index.php
@@ -9,6 +9,35 @@
  */
 
 /**
+ * Register Custom Block Styles
+ */
+if ( function_exists( 'register_block_style' ) ) {
+	function block_styles_register_block_styles() {
+		/**
+		 * Register stylesheet
+		 */
+		wp_register_style(
+			'block-styles-stylesheet',
+			plugins_url( 'style.css', __FILE__ ),
+			array(),
+			'1.1'
+		);
+
+		/**
+		 * Register block style
+		 */
+		register_block_style(
+			'core/paragraph',
+			array(
+				'name'         => 'blue-paragraph',
+				'label'        => 'Blue Paragraph',
+				'style_handle' => 'block-styles-stylesheet',
+			)
+		);
+	}
+
+	add_action( 'init', 'block_styles_register_block_styles' );
+}
  * Enqueue Block Styles Stylesheet
  */
 function block_styles_enqueue_stylesheet() {

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/Automattic/gutenberg-block-styles/
  * Description: A simple plugin to demonstrate how to add block styles to Gutenberg.
  * Version: 1.1
- * Author: Kjell Reigstad
+ * Author: Automattic
  */
 
 /**

--- a/index.php
+++ b/index.php
@@ -4,20 +4,9 @@
  * Plugin Name: Gutenberg Block Styles
  * Plugin URI: https://github.com/Automattic/gutenberg-block-styles/
  * Description: A simple plugin to demonstrate how to add block styles to Gutenberg.
- * Version: 1.0
+ * Version: 1.1
  * Author: Kjell Reigstad
  */
-
-/**
- * Enqueue Block Styles Javascript
- */
-function block_styles_enqueue_javascript() {
-	wp_enqueue_script( 'block-styles-script',
-		plugins_url( 'block.js', __FILE__ ),
-		array( 'wp-blocks')
-	);
-}
-add_action( 'enqueue_block_editor_assets', 'block_styles_enqueue_javascript' );
 
 /**
  * Enqueue Block Styles Stylesheet
@@ -28,3 +17,17 @@ function block_styles_enqueue_stylesheet() {
 	);
 }
 add_action( 'enqueue_block_assets', 'block_styles_enqueue_stylesheet' );
+
+/**
+ * Register Block Styles
+ */
+if ( function_exists( 'register_block_style' ) ) {
+	register_block_style(
+		'core/paragraph',
+		array(
+			'name'			=> 'blue-paragraph',
+			'label'			=> 'Blue Paragraph',
+			'style_handle'	=> 'block-styles-stylesheet',
+		)
+	);
+}


### PR DESCRIPTION
This PR updates the repo to rely on the server-side registration helper. This approach is simpler in that it eliminates the need for JavaScript.

It also updates the Readme to reflect the new approach, and to point people to the Block Editor handbook for more details. 

## Testing

1. Clone this repo/PR
2. Zip it up and install it as a WordPress plugin. 
3. Activate the "Gutenberg Block Styles" plugin. 
4. Open the block editor, and verify that paragraph blocks have a "Blue Paragraph" block style: 

<img width="639" alt="Screen Shot 2020-01-13 at 9 40 43 AM" src="https://user-images.githubusercontent.com/1202812/72264523-e2ae9b00-35e8-11ea-96bc-df8a55ed32da.png">
